### PR TITLE
chore: Update zeabur configuration

### DIFF
--- a/zbpack.json
+++ b/zbpack.json
@@ -1,0 +1,8 @@
+{
+  "rust": {
+    "entry": "blah"
+  },
+  "start_command": "/app/main --listen=0.0.0.0:8080 --database=/db.sqlite3 --base-url=https://blah-backend.zeabur.app",
+  "build_command": "apt update && apt install -y sqlite3",
+  "pre_start_command": "apt update && apt install -y sqlite3 && rm -rf /var/lib/apt/lists/*"
+}


### PR DESCRIPTION
FIXME:

- `/db.sqlite3` will be **reset** when triggering a new deployment. How about using [LibSQL server](https://github.com/tursodatabase/libsql) for the data persistence storage? I also deployed one on Zeabur.